### PR TITLE
Fix redo method of Task

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -543,7 +543,7 @@ class Task(Persistable, Struct):
             return self.execution.returncode
 
 
-    def redo(self):
+    def redo(self, *args, **kwargs):
         """
         Reset the state of this Task instance to ``NEW``.
 


### PR DESCRIPTION
The method did not accept any additional arguments or keyword arguments.