### PR TITLE
Feature/construct session with existing store

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -543,7 +543,7 @@ class Task(Persistable, Struct):
             return self.execution.returncode
 
 
-    def redo(self):
+    def redo(self, *args, **kwargs):
         """
         Reset the state of this Task instance to ``NEW``.
 

--- a/gc3libs/persistence/filesystem.py
+++ b/gc3libs/persistence/filesystem.py
@@ -72,8 +72,13 @@ class FilesystemStore(Store):
                  idfactory=IdFactory(),
                  protocol=DEFAULT_PROTOCOL,
                  **extra_args):
+        # In my opinion, not the path, but the url should be parsed to the
+        # constructor for compatibility with SqlStore!
         if isinstance(directory, gc3libs.url.Url):
+            super(FilesystemStore, self).__init__(directory)
             directory = directory.path
+        else:
+            super(FilesystemStore, self).__init__()
         self._directory = directory
 
         self.idfactory = idfactory
@@ -246,3 +251,4 @@ if "__main__" == __name__:
     import doctest
     doctest.testmod(name="filesystem",
                     optionflags=doctest.NORMALIZE_WHITESPACE)
+

--- a/gc3libs/persistence/sql.py
+++ b/gc3libs/persistence/sql.py
@@ -147,6 +147,7 @@ class SqlStore(Store):
         url. It will use the correct backend (MySQL, psql, sqlite3)
         based on the url.scheme value
         """
+        super(SqlStore, self).__init__(url)
         self._engine = sqla.create_engine(str(url))
         self.table_name = table_name
 
@@ -308,3 +309,4 @@ if "__main__" == __name__:
     import doctest
     doctest.testmod(name="sql",
                     optionflags=doctest.NORMALIZE_WHITESPACE)
+

--- a/gc3libs/persistence/store.py
+++ b/gc3libs/persistence/store.py
@@ -47,6 +47,9 @@ class Store(object):
         parts of the code.
     """
 
+    def __init__(self, url=None):
+        self.url = url
+
     def list(self, **extra_args):
         """
         Return list of IDs of saved `Job` objects.
@@ -111,15 +114,6 @@ class Persistable(object):
         except AttributeError:
             return super(Persistable, self).__str__()
 
-    def __eq__(self, other):
-        try:
-            return self.persistent_id == other.persistent_id
-        except AttributeError:
-            # fall back to Python object comparison
-            return super(Persistable, self) == other
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
 # registration mechanism
 
@@ -194,7 +188,7 @@ def make_store(uri, *args, **extra_args):
                 'mssql',
                 'mysql',
                 'oracle',
-                'postgres',
+                'postgresql',
                 'sqlite',
         ]:
             import gc3libs.persistence.sql


### PR DESCRIPTION
The session can currently only be constructed via the ``store_url``. I have a use case were it would be better to create a ``SqlStore`` object once and then reuse it for the creation of different sessions. The engine constructor accepts a store object. The same should in my opinion apply to the session constructor. Currently, all arguments for the store constructor (``table_name``, ``extra_fields``, ...) need to be parsed. It would thus make more sense to simply parse the store object directly.

In addition, the store object is lacking a ``url`` attribute. To this end, I added a constructor to the base class. Thereby, I realised that there is an inconsistency between the ``SqlStore`` and the ``FilesystemStore``. To former accepts the url, while the latter accepts the path to the file rather than the full url. This should be changed in my opinion.