### PR TITLE
Fixes 'illegal -N value'

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -1424,7 +1424,7 @@ class Application(Task):
             # require that all cores are on the same node
             qsub += ['-l', 'nodes=1:ppn=%d' % self.requested_cores]
         if 'jobname' in self and self.jobname:
-            qsub += ['-N', '"%s"' % self.jobname[:15]]
+            qsub += ['-N', '%s' % self.jobname[:15]]
         return (qsub, self.cmdline(resource))
 
     def sbatch(self, resource, **extra_args):


### PR DESCRIPTION
We are not able to submit PBS jobs with the name set. We are running this version of PBS:

```bash
[root@login4.salomon ~]# qsub --version
pbs_version = PBSPro_13.1.1.162303
```

This MR fixes the issue.