### PR TITLE
Proposal for fix #628,  #621

### DIFF
--- a/gc3apps/aim.uzh/gqhg.py
+++ b/gc3apps/aim.uzh/gqhg.py
@@ -34,6 +34,7 @@ __changelog__ = """
 """
 __author__ = 'Sergio Maffioletti <sergio.maffioletti@uzh.ch>'
 __docformat__ = 'reStructuredText'
+__version__ = '1.0.0'
 
 # run script, but allow GC3Pie persistence module to access classes defined here;
 # for details, see: https://github.com/uzh/gc3pie/issues/95

--- a/gc3apps/ieu.uzh.ch/gmbsim.py
+++ b/gc3apps/ieu.uzh.ch/gmbsim.py
@@ -31,7 +31,7 @@ __changelog__ = """
 """
 __author__ = 'Riccardo Murri <riccardo.murri@uzh.ch>'
 __docformat__ = 'reStructuredText'
-
+__version__ = '1.0.0'
 
 # run script, but allow GC3Pie persistence module to access classes defined here;
 # for details, see: https://github.com/uzh/gc3pie/issues/95

--- a/gc3libs/backends/ec2.py
+++ b/gc3libs/backends/ec2.py
@@ -965,7 +965,7 @@ class EC2Lrms(LRMS):
         # if no more applications are currently running, turn the instance off
         # check with the associated resource
         resource.get_resource_status()
-        if len(resource.job_infos) == 0:
+        if resource.running_jobs() == 0:
             # turn VM off
             vm = self._get_vm(app.execution._lrms_vm_id)
             gc3libs.log.info("VM instance %s at %s is no longer needed."
@@ -987,7 +987,7 @@ class EC2Lrms(LRMS):
         # Update status of VMs and remote resources
         self.get_resource_status()
         for vm_id, resource in self.subresources.items():
-            if resource.updated and not resource.job_infos:
+            if resource.updated and (resource.running_jobs() > 0):
                 vm = self._get_vm(vm_id)
                 gc3libs.log.warning(
                     "VM instance %s at %s is no longer needed. "

--- a/gc3libs/backends/openstack.py
+++ b/gc3libs/backends/openstack.py
@@ -1079,7 +1079,7 @@ class OpenStackLrms(LRMS):
         # if no more applications are currently running, turn the instance off
         # check with the associated resource
         subresource.get_resource_status()
-        if len(subresource.job_infos) == 0:
+        if subresource.running_jobs() == 0:
             # turn VM off
             vm = self._get_vm(app.execution._lrms_vm_id)
 
@@ -1101,7 +1101,7 @@ class OpenStackLrms(LRMS):
         # Update status of VMs and remote resources
         self.get_resource_status()
         for vm_id, subresource in self.subresources.items():
-            if subresource.updated and not subresource.job_infos:
+            if subresource.updated and (subresource.running_jobs() > 0):
                 vm = self._get_vm(vm_id)
                 gc3libs.log.warning(
                     "VM instance %s at %s is no longer needed. "

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -1101,7 +1101,9 @@ class ShellcmdLrms(LRMS):
             # lrms_jobid not yet assigned; probably submit
             # failed -- ignore and continue
             pass
-
+    
+    def running_jobs(self):
+        return len(self._job_infos)
 
     @same_docstring_as(LRMS.get_resource_status)
     def get_resource_status(self):

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -1058,7 +1058,7 @@ class ShellcmdLrms(LRMS):
             else:
                 # ignore
                 pass
-        self._delete_job_info_file(root_pid)
+        # self._delete_job_info_file(root_pid)
 
     def _grace_time(self, wait):
         if wait:
@@ -1610,8 +1610,8 @@ class ShellcmdLrms(LRMS):
                    .format(wrapper_filename, app, err))
             log.warning("%s -- Termination status and resource utilization fields will not be set.", msg)
             raise gc3libs.exceptions.InvalidValue(msg)
-        finally:
-            self._delete_job_info_file(pid)
+        # finally:
+        #     self._delete_job_info_file(pid)
 
     def _parse_wrapper_output(self, wrapper_file):
         """

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -1102,6 +1102,9 @@ class ShellcmdLrms(LRMS):
             pass
     
     def running_jobs(self):
+        """
+        Returns number of currently running jobs.
+        """
         return len(self._job_infos)
 
     @same_docstring_as(LRMS.get_resource_status)

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -1058,7 +1058,6 @@ class ShellcmdLrms(LRMS):
             else:
                 # ignore
                 pass
-        # self._delete_job_info_file(root_pid)
 
     def _grace_time(self, wait):
         if wait:
@@ -1610,8 +1609,6 @@ class ShellcmdLrms(LRMS):
                    .format(wrapper_filename, app, err))
             log.warning("%s -- Termination status and resource utilization fields will not be set.", msg)
             raise gc3libs.exceptions.InvalidValue(msg)
-        # finally:
-        #     self._delete_job_info_file(pid)
 
     def _parse_wrapper_output(self, wrapper_file):
         """

--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -19,8 +19,7 @@ via SSH.
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
 #
 __docformat__ = 'reStructuredText'
 
@@ -722,7 +721,7 @@ class SshTransport(Transport):
 
     @same_docstring_as(Transport.makedirs)
     def makedirs(self, path, mode=0o777):
-        gc3libs.log.debug("Making remote directory path '%s' ...", path)        
+        gc3libs.log.debug("Making remote directory path '%s' ...", path)
         dirs = path.split('/')
         if '..' in dirs:
             raise gc3libs.exceptions.InvalidArgument(
@@ -946,7 +945,7 @@ class LocalTransport(Transport):
     def execute_command(self, command, detach=False):
         assert self._is_open is True, \
             "`Transport.execute_command()` called" \
-            " on `Transport` instance closed / not yet open"
+            " on closed (or not yet opened) `Transport` instance."
         if detach:
             command = command + ' &'
         try:

--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -19,7 +19,7 @@ via SSH.
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program; If not, see <http://www.gnu.org/licenses/>.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 __docformat__ = 'reStructuredText'
 

--- a/gc3utils/commands.py
+++ b/gc3utils/commands.py
@@ -1800,7 +1800,7 @@ To get detailed info on a specific command, run:
             ips = []
             if vm.id in res.subresources:
                 if res.subresources[vm.id].updated:
-                    remote_jobs = str(len(res.subresources[vm.id].job_infos))
+                    remote_jobs = str(res.subresources[vm.id].running_jobs())
                     ncores = str(res.subresources[vm.id].max_cores)
 
             if res.type.startswith('ec2'):
@@ -1892,7 +1892,7 @@ To get detailed info on a specific command, run:
             vms = res._vmpool.get_all_vms()
             if vms:
                 for vm in vms:
-                    remote_jobs = len(res.subresources[vm.id].job_infos)
+                    remote_jobs = res.subresources[vm.id].running_jobs()
                     if remote_jobs == 0:
                         if self.params.dry_run:
                             print("No job running on VM `%s` of resource `%s`;"


### PR DESCRIPTION
* Fix #628: introduced 'running_jobs()' method on ShellCmd backend to return the number of currently running jobs.
* Fix #621: fixed use of 'None' username for ssh connections by avoiding that connection parameters like 'uername' or 'keyfile' are overrritten when 'set_connection_params' method is called.
* avoid deleting ShellCmd remote job's PID files as part of the '_cleanup_terminating_task' as the method get called in several differnt phases of the job lifecycle. Removal of remote job's PID file should only be part of the 'free' method.

