### PR TITLE
Sergio: align with gc3pie master

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -484,7 +484,13 @@ class Task(Persistable, Struct):
 
         See :meth:`gc3libs.Core.free` for a full explanation.
         """
-        return
+        assert self._attached, ("Task.free() called on detached task %s." %
+                                self)
+        assert hasattr(self._controller, 'free'), \
+            ("Invalid `_controller` object '%s' in Task %s" %
+             (self._controller, self))
+        self._controller.free(self, **extra_args)
+ 
 
     # convenience methods, do not really add any functionality over
     # what's above

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -229,7 +229,7 @@ class _Machine(object):
 
         Raise ``LookupError`` if no process is identified by the given PID.
         """
-        cmd = 'ps -p {0:d} -o state='.format(pid)
+        cmd = 'ps -p {0} -o state='.format(pid)
         rc, stdout, stderr = self.transport.execute_command(cmd)
         if rc == 1:  # FIXME: same return code on MacOSX?
             raise LookupError('No process with PID {0}'.format(pid))
@@ -245,7 +245,7 @@ class _Machine(object):
 
         Raise ``LookupError`` if no process is identified by the given PID.
         """
-        cmd = 'ps -p {0:d} -o etime='.format(pid)
+        cmd = 'ps -p {0} -o etime='.format(pid)
         rc, stdout, stderr = self.transport.execute_command(cmd)
         if rc == 1:  # FIXME: same return code on MacOSX?
             raise LookupError('No process with PID {0}'.format(pid))
@@ -297,7 +297,7 @@ class _Machine(object):
         """Machine-specific part of `get_total_memory`."""
         pass
 
-    def list_process_tree(self, root_pid=1):
+    def list_process_tree(self, root_pid="1"):
         """
         Return list of PIDs of children of the given process.
 
@@ -316,7 +316,7 @@ class _Machine(object):
             if not line:
                 continue
             pid, ppid = line.split()
-            children[int(ppid)].append(int(pid))
+            children[ppid].append(pid)
         if root_pid not in children:
             return []
 
@@ -981,7 +981,7 @@ class ShellcmdLrms(LRMS):
         stored (by `submit_job`:meth:) as `app.execution.lrms_jobid`.
         """
         try:
-            root_pid = int(app.execution.lrms_jobid)
+            root_pid = app.execution.lrms_jobid
         except ValueError:
             raise gc3libs.exceptions.InvalidArgument(
                 "Invalid field `lrms_jobid` in Task '{0}':"
@@ -1539,8 +1539,7 @@ class ShellcmdLrms(LRMS):
         for retry in gc3libs.utils.ExponentialBackoff():
             try:
                 with self.transport.open(pidfile_path, 'r') as pidfile:
-                    pid = pidfile.read().strip()
-                    return int(pid)
+                    return pidfile.read().strip()
             except ValueError:
                 # it happens that the PID file exists, but `.read()`
                 # returns the empty string... just wait and retry.

--- a/gc3libs/backends/tests/test_machine.py
+++ b/gc3libs/backends/tests/test_machine.py
@@ -85,16 +85,16 @@ def test_list_process_tree_full(transport):
         '',
     )
 
-    pids = mach.list_process_tree(2361)
+    pids = mach.list_process_tree("2361")
     assert pids == [
               # PID   PPID CMD
-        2361, # 2361  1466 /sbin/upstart --user
-        2431, # 2431  2361  \_ upstart-udev-bridge --daemon --user
-        2663, # 2663  2361  \_ gpg-agent --homedir /home/rmurri/.gnupg --use-standard-socket --daemon
-        2679, # 2679  2361  \_ /usr/lib/at-spi2-core/at-spi-bus-launcher
-        2725, # 2684  2679  |   \_ /usr/bin/dbus-daemon --config-file=/etc/at-spi2/accessibility.conf --nofork --print-address 3
-        2684, # 2725  2361  \_ /usr/bin/lxsession -s Lubuntu -e LXDE
-        2736, # 2736  2725  |   \_ lxpanel --profile Lubuntu
+        "2361", # 2361  1466 /sbin/upstart --user
+        "2431", # 2431  2361  \_ upstart-udev-bridge --daemon --user
+        "2663", # 2663  2361  \_ gpg-agent --homedir /home/rmurri/.gnupg --use-standard-socket --daemon
+        "2679", # 2679  2361  \_ /usr/lib/at-spi2-core/at-spi-bus-launcher
+        "2725", # 2684  2679  |   \_ /usr/bin/dbus-daemon --config-file=/etc/at-spi2/accessibility.conf --nofork --print-address 3
+        "2684", # 2725  2361  \_ /usr/bin/lxsession -s Lubuntu -e LXDE
+        "2736", # 2736  2725  |   \_ lxpanel --profile Lubuntu
     ]
 
 

--- a/gc3libs/backends/tests/test_shellcmd.py
+++ b/gc3libs/backends/tests/test_shellcmd.py
@@ -415,5 +415,37 @@ type=none
             core1.free(app)
 
 
+    def test_pid_list_is_string(self):
+        tmpdir = tempfile.mkdtemp(prefix=__name__, suffix='.d')
+        (fd, cfgfile) = tempfile.mkstemp()
+        f = os.fdopen(fd, 'w+')
+        f.write(TestBackendShellcmdCFG.CONF % ("False", cfgfile + '.d'))
+        f.close()
+        self.files_to_remove = [cfgfile, cfgfile + '.d']
+
+        self.cfg = gc3libs.config.Configuration()
+        self.cfg.merge_file(cfgfile)
+
+        self.core = gc3libs.core.Core(self.cfg)
+        self.backend = self.core.get_backend('localhost_test')
+        # Update resource status
+
+        app = gc3libs.Application(
+        arguments=['/bin/echo', 'Hello', 'World'],
+            inputs=[],
+            outputs=[],
+            output_dir=tmpdir,
+            requested_cores=1,
+            requested_memory=10 * Memory.MiB, )
+
+        try:
+            self.core.submit(app)
+            for pid in self.backend._job_infos.keys():
+                assert isinstance(pid,str)
+        finally:
+            self.core.kill(app)
+            self.core.free(app)            
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/gc3utils/commands.py
+++ b/gc3utils/commands.py
@@ -1155,13 +1155,12 @@ To get detailed info on a specific command, run:
                 continue
             try:
                 task.kill()
+                task.free()
+                rc -= 1
             except gc3libs.exceptions.Error, err:
                 gc3libs.log.error(
                     "Could not abort task '%s': %s: %s",
                     task, err.__class__.__name__, err)
-            finally:
-                task.free()
-                rc -= 1
 
         if rc:
             gc3libs.log.error(


### PR DESCRIPTION
'task.free()' method delegate to attached controller - e.g. core or engine - the free operation.
This should fix the gsession abort behaviour of not terminating running instances.
Additionally, in shellcmd pids are consistently treated as strings in self._job_infos dictionary