### PR TITLE
Spooldir as config item in backend resource

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -104,7 +104,7 @@ class Default(object):
 
     # time to cache lshosts/bjobs information for
     LSF_CACHE_TIME = 30
-
+    SPOOLDIR = "/var/tmp"
 
 from gc3libs.events import TaskStateChange
 import gc3libs.exceptions

--- a/gc3libs/backends/batch.py
+++ b/gc3libs/backends/batch.py
@@ -193,7 +193,7 @@ class BatchSystem(LRMS):
     def _init_spooldir(self):
         """Set `self.spooldir` to a sensible value."""
         rc, stdout, stderr = self.transport.execute_command(
-            'cd "${TMPDIR:-{0}}" && pwd'.format(gc3libs.Default.SPOOLDIR))
+            'cd "${TMPDIR:-%s}" && pwd' % gc3libs.Default.SPOOLDIR)
         if (rc != 0 or stdout.strip() == '' or stdout[0] != '/'):
             raise gc3libs.exceptions.SpoolDirError("Unable to recover a valid path for `spooldir` "
                                                    "on resource {0}. "

--- a/gc3libs/backends/batch.py
+++ b/gc3libs/backends/batch.py
@@ -192,6 +192,7 @@ class BatchSystem(LRMS):
 
     def _init_spooldir(self):
         """Set `self.spooldir` to a sensible value."""
+        self.transport.connect()
         rc, stdout, stderr = self.transport.execute_command(
             'cd "${TMPDIR:-%s}" && pwd' % gc3libs.Default.SPOOLDIR)
         if (rc != 0 or stdout.strip() == '' or stdout[0] != '/'):

--- a/gc3libs/backends/batch.py
+++ b/gc3libs/backends/batch.py
@@ -125,6 +125,7 @@ class BatchSystem(LRMS):
                  ssh_timeout=None,
                  large_file_threshold=None,
                  large_file_chunk_size=None,
+                 spooldir = None,
                  **extra_args):
 
         # init base class
@@ -132,6 +133,13 @@ class BatchSystem(LRMS):
             self, name,
             architecture, max_cores, max_cores_per_job,
             max_memory_per_core, max_walltime, auth, **extra_args)
+
+
+        # default is to use $TMPDIR or '/var/tmp' (see
+        # `tempfile.mkftemp`), but we delay the determination of the
+        # correct dir to the submit_job, so that we don't have to use
+        # `transport` right now.
+        self.spooldir = spooldir
 
         # backend-specific setup
         self.frontend = frontend
@@ -156,6 +164,44 @@ class BatchSystem(LRMS):
             raise gc3libs.exceptions.TransportError(
                 "Unknown transport '%s'" % transport)
         self.accounting_delay = accounting_delay
+
+
+    @property
+    def spooldir(self):
+        """
+        Root folder for all working directories of GC3Pie tasks.
+
+        When this backend executes a task, it first creates a temporary
+        subdirectory of this folder, then launches commands in there.
+
+        If not explicitly set (e.g. at construction time), the "spool
+        directory" will be given a default value according to the logic of
+        :meth:`_discover_spooldir`:
+
+        * If the remote environment variable ``TMPDIR`` is set and points to an
+          existing directory, that value is used;
+        * otherwise, the hard-coded default ``/var/tmp`` is used instead.
+        """
+        if not self._spooldir:
+            self._init_spooldir()
+        return self._spooldir
+
+    @spooldir.setter
+    def spooldir(self, value):
+        self._spooldir = value
+
+    def _init_spooldir(self):
+        """Set `self.spooldir` to a sensible value."""
+        rc, stdout, stderr = self.transport.execute_command(
+            'cd "${TMPDIR:-{0}}" && pwd'.format(gc3libs.Default.SPOOLDIR))
+        if (rc != 0 or stdout.strip() == '' or stdout[0] != '/'):
+            raise gc3libs.exceptions.SpoolDirError("Unable to recover a valid path for `spooldir` "
+                                                   "on resource {0}. "
+                                                   "Neither {1} nor {2} have worked.".format(self.name,
+                                                                                             self.spooldir,
+                                                                                             gc3libs.Default.SPOOLDIR))
+        else:
+            self.spooldir = stdout.strip()
 
     def get_jobid_from_submit_output(self, output, regexp):
         """Parse the output of the submission command. Regexp is
@@ -402,9 +448,8 @@ class BatchSystem(LRMS):
         # Create the remote directory.
         try:
             self.transport.connect()
-
-            cmd = "mkdir -p $HOME/.gc3pie_jobs;" \
-                " mktemp -d $HOME/.gc3pie_jobs/lrms_job.XXXXXXXXXX"
+            cmd = "mkdir -p {0}/.gc3pie_jobs;" \
+                " mktemp -d {0}/.gc3pie_jobs/lrms_job.XXXXXXXXXX".format(self.spooldir)
             log.info("Creating remote temporary folder: command '%s' " % cmd)
             exit_code, stdout, stderr = self.transport.execute_command(cmd)
             if exit_code == 0:

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -713,7 +713,7 @@ class ShellcmdLrms(LRMS):
     def _init_spooldir(self):
         """Set `self.spooldir` to a sensible value."""
         rc, stdout, stderr = self.transport.execute_command(
-            'cd "${TMPDIR:-{0}}" && pwd'.format(gc3libs.Default.SPOOLDIR))
+            'cd "${TMPDIR:-%s}" && pwd' % gc3libs.Default.SPOOLDIR)
         if (rc != 0 or stdout.strip() == '' or stdout[0] != '/'):
             raise SpoolDirError("Unable to recover a valid path for `spooldir` "
                                 "on resource {0}. "

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -713,15 +713,15 @@ class ShellcmdLrms(LRMS):
     def _init_spooldir(self):
         """Set `self.spooldir` to a sensible value."""
         rc, stdout, stderr = self.transport.execute_command(
-            'cd "${TMPDIR:-/var/tmp}" && pwd')
+            'cd "${TMPDIR:-{0}}" && pwd'.format(gc3libs.Default.SPOOLDIR))
         if (rc != 0 or stdout.strip() == '' or stdout[0] != '/'):
-            log.debug(
-                "Unable to recover a valid absolute path for `spooldir`"
-                " on resource `%s`. Using `/var/tmp`.", self.name)
-            self.spooldir = '/var/tmp'
+            raise SpoolDirError("Unable to recover a valid path for `spooldir` "
+                                "on resource {0}. "
+                                "Neither {1} nor {2} have worked.".format(self.name,
+                                                                          self.spooldir,
+                                                                          gc3libs.Default.SPOOLDIR))
         else:
             self.spooldir = stdout.strip()
-
 
     @property
     def time_cmd(self):

--- a/gc3libs/exceptions.py
+++ b/gc3libs/exceptions.py
@@ -174,7 +174,6 @@ class UnrecoverableDataStagingError(DataStagingError, UnrecoverableError):
     """
     pass
 
-
 class InputFileError(FatalError):
 
     """
@@ -482,6 +481,13 @@ class ApplicationDescriptionError(FatalError):
 
     """
     pass
+
+class SpoolDirError(InvalidValue, UnrecoverableError):
+
+    """
+    Raised when a backend fails to access the spooldir either because
+    it does not exists or cannot be read.
+    """
 
 
 # main: run tests

--- a/gc3libs/tests/test_config.py
+++ b/gc3libs/tests/test_config.py
@@ -613,15 +613,19 @@ app2_epilogue_content = echo epilogue app2
     def test_pbs_prologue_and_epilogue_contents_when_files(self):
         """Prologue and epilogue scripts are inserted in the submission script
         """
-        # Ugly hack. We have to list the job dirs to check which one
-        # is the new one.
-        jobdir = os.path.expanduser('~/.gc3pie_jobs')
-        jobs = []
-        if os.path.isdir(jobdir):
-            jobs = os.listdir(jobdir)
         app = Application(['/bin/true'], [], [], '')
         self.core = gc3libs.core.Core(self.cfg)
         self.core.select_resource('testpbs')
+
+        # get the selected resource
+        lrms = [ resource for resource in self.core.get_resources() if resource.name == 'testpbs'][0]
+        # Ugly hack. We have to list the job dirs to check which one
+        # is the new one.
+        jobdir = os.path.expanduser('{0}/.gc3pie_jobs'.format(lrms.spooldir))
+        jobs = []
+        if os.path.isdir(jobdir):
+            jobs = os.listdir(jobdir)
+
         try:
             self.core.submit(app)
         except Exception:
@@ -658,16 +662,20 @@ app2_epilogue_content = echo epilogue app2
     def test_pbs_prologue_and_epilogue_contents_when_not_files(self):
         """Prologue and epilogue scripts are inserted in the submission script
         """
-        # Ugly hack. We have to list the job dirs to check which one
-        # is the new one.
-        jobdir = os.path.expanduser('~/.gc3pie_jobs')
-        jobs = []
-        if os.path.isdir(jobdir):
-            jobs = os.listdir(jobdir)
         app = Application(['/bin/true'], [], [], '')
         app.application_name = 'app2'
         self.core = gc3libs.core.Core(self.cfg)
         self.core.select_resource('testpbs')
+
+        # get the selected resource
+        lrms = [ resource for resource in self.core.get_resources() if resource.name == 'testpbs'][0]
+        # Ugly hack. We have to list the job dirs to check which one
+        # is the new one.
+        jobdir = os.path.expanduser('{0}/.gc3pie_jobs'.format(lrms.spooldir))
+        jobs = []
+        if os.path.isdir(jobdir):
+            jobs = os.listdir(jobdir)
+
         try:
             self.core.submit(app)
         except Exception:


### PR DESCRIPTION
new config file item `spooldir` is recognized in the [resource] section of the `gc3pie.conf` file and it is used by `shellcmd` and batch `backends` to prefix the location of the job's execution folder on the worker nodes.
