### PR TITLE
Unicode

### DIFF
--- a/gc3libs/__init__.py
+++ b/gc3libs/__init__.py
@@ -1816,7 +1816,7 @@ class Run(Struct):
             return self.history.last()
 
         def fset(self, value):
-            self.history.append(unicode(value))
+            self.history.append(unicode(value, errors='replace'))
         return locals()
 
     # states that a `Run` can be in

--- a/gc3libs/backends/shellcmd.py
+++ b/gc3libs/backends/shellcmd.py
@@ -1073,7 +1073,7 @@ class ShellcmdLrms(LRMS):
         this method on the same applications do nothing.
         """
         try:
-            if app.execution.lrms_execdir is not None:
+            if (hasattr(app.execution, 'lrms_execdir') and app.execution.lrms_execdir is not None):
                 log.debug('Deleting working directory of task `%s` ...', app)
                 self.transport.connect()
                 if self.transport.isdir(app.execution.lrms_execdir):
@@ -1377,7 +1377,7 @@ class ShellcmdLrms(LRMS):
             raise gc3libs.exceptions.SpoolDirError(
                 "Cannot create temporary job working directory"
                 " `{0}` on host `{1}`; command `{2}` exited"
-                " with code {3} and error output: '{4}'."
+                " with code {3} and error output: `{4}`."
                 .format(target, self.frontend, cmd, exit_code, stderr))
         return stdout.strip()
 


### PR DESCRIPTION
1. Handle case when string will not in ascii format.
2. handle case when shellcmd.free() is called priori application.execution.lrms_execdir is created - e.g. when the creation of the lrms_execdir fails as part of the submit_job method