### PR TITLE
Fix virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,4 @@ install:
   - "pip install --upgrade setuptools pip"
   - "pip install 'pytest==3.2.5' mock"
   - "pip install -e .[openstack,ec2,daemon]"
-script:
-  - export BOTO_CONFIG=/dev/null
-  - pytest -v
+script: pytest -v

--- a/install.py
+++ b/install.py
@@ -1039,7 +1039,7 @@ def yes_or_no(value):
 
 
 def search_for(path, filename):
-    for r,d,f in os.walk(path):
+    for rootdir, dirs, filenames in os.walk(path):
         if os.path.isfile(os.path.join(r,filename)):
             return os.path.abspath(os.path.join(r,filename))
 

--- a/install.py
+++ b/install.py
@@ -402,7 +402,6 @@ bug to the GC3Pie mailing list gc3pie@googlegroups.com
     cleanup_defer(venvsourcedir)
 
     # search 'virtualenv.py'
-    # venvpath = os.path.join(venvsourcedir, 'virtualenv.py')
     venvpath = search_for(venvsourcedir, 'virtualenv.py')
     if not venvpath:
         die(os.EX_SOFTWARE,

--- a/install.py
+++ b/install.py
@@ -114,7 +114,7 @@ class default:
     TARGET = path.expandvars('$HOME/gc3pie')
     UNRELEASED = False
     WITH_APPS = True
-
+    VIRTUALENV = "15.2.0"
 
 # by default, ask for confirmation
 DO_NOT_ASK_AND_ASSUME_YES = False
@@ -394,21 +394,29 @@ bug to the GC3Pie mailing list gc3pie@googlegroups.com
         # no issue in allowing access to system site packages
         with_site_packages = ['--system-site-packages']
 
-    tarball = download_from_pypi('virtualenv', keep=False)
+    # Check condition that requires us to skip download virtualenv:
+    # virtualenv already installed
+    if have_command('virtualenv'):
+        # run command
+        logging.info('Using system virtualenv... ')
+        cmd = [find_executable("virtualenv")] + with_site_packages + ['-p', python, destdir]
+    else:
+        # get virtualenv package
+        # Force version <= 15 as in newer versions,
+        # binary file is no-loner provided
+        tarball = download_from_pypi('virtualenv', version=default.VIRTUALENV, keep=False)
 
-    tar = tarfile.open(tarball)
-    tar.extractall()
-    venvsourcedir = tar.getnames()[0]
-    cleanup_defer(venvsourcedir)
+        tar = tarfile.open(tarball)
+        tar.extractall()
+        venvsourcedir = tar.getnames()[0]
+        cleanup_defer(venvsourcedir)
 
-    venvpath = os.path.join(venvsourcedir, 'virtualenv.py')
+        venvpath = os.path.join(venvsourcedir, 'virtualenv.py')
+        cmd = [python, venvpath] + with_site_packages + ['-p', python, destdir]
 
     # run: python virtualenv.py --[no,system]-site-packages $DESTDIR
     try:
-        check_call(
-            [python, venvpath]
-            + with_site_packages
-            + ['-p', python, destdir])
+        check_call(cmd)
         logging.info("Created Python virtual environment in '%s'", destdir)
     except CalledProcessError as err:
         rc = err.returncode
@@ -560,6 +568,7 @@ def download_from_pypi(pkgname, pip_url=default.BASE_PIP_URL, version=None, keep
     one actually downloaded is the one which comes first in Python
     string sorting order.
     """
+
     base_url = (pip_url + '/' + pkgname + '/json')
     try:
         data = urlopen(base_url).read()

--- a/install.py
+++ b/install.py
@@ -407,7 +407,7 @@ bug to the GC3Pie mailing list gc3pie@googlegroups.com
         die(os.EX_SOFTWARE,
             "Failed to locate `virtualenv.py`.",
             """
-            Failed to localte `virtualenv.py` from dowloaded package
+            Failed to locale `virtualenv.py` in dowloaded package directory `{0}`
             in {0}.
             """.format(venvsourcedir))
 

--- a/install.py
+++ b/install.py
@@ -1040,7 +1040,7 @@ def yes_or_no(value):
 
 def search_for(path, filename):
     for rootdir, dirs, filenames in os.walk(path):
-        if os.path.isfile(os.path.join(r,filename)):
+        if filename in filenames:
             return os.path.abspath(os.path.join(rootdir, filename))
 
     # could not find `filename`; return None

--- a/install.py
+++ b/install.py
@@ -1041,7 +1041,7 @@ def yes_or_no(value):
 def search_for(path, filename):
     for rootdir, dirs, filenames in os.walk(path):
         if os.path.isfile(os.path.join(r,filename)):
-            return os.path.abspath(os.path.join(r,filename))
+            return os.path.abspath(os.path.join(rootdir, filename))
 
     # could not find `filename`; return None
     return None

--- a/install.py
+++ b/install.py
@@ -401,7 +401,16 @@ bug to the GC3Pie mailing list gc3pie@googlegroups.com
     venvsourcedir = tar.getnames()[0]
     cleanup_defer(venvsourcedir)
 
-    venvpath = os.path.join(venvsourcedir, 'virtualenv.py')
+    # search 'virtualenv.py'
+    # venvpath = os.path.join(venvsourcedir, 'virtualenv.py')
+    venvpath = search_for(venvsourcedir, 'virtualenv.py')
+    if not venvpath:
+        die(os.EX_SOFTWARE,
+            "Failed to locate `virtualenv.py`.",
+            """
+            Failed to localte `virtualenv.py` from dowloaded package
+            in {0}.
+            """.format(venvsourcedir))
 
     # run: python virtualenv.py --[no,system]-site-packages $DESTDIR
     try:
@@ -1030,6 +1039,14 @@ def which_missing_packages(pkgs):
 def yes_or_no(value):
     return ('yes' if value else 'no')
 
+
+def search_for(path, filename):
+    for r,d,f in os.walk(path):
+        if os.path.isfile(os.path.join(r,filename)):
+            return os.path.abspath(os.path.join(r,filename))
+
+    # could not find `filename`; return None
+    return None
 
 if __name__ == '__main__':
     main()

--- a/install.py
+++ b/install.py
@@ -408,7 +408,6 @@ bug to the GC3Pie mailing list gc3pie@googlegroups.com
             "Failed to locate `virtualenv.py`.",
             """
             Failed to locale `virtualenv.py` in dowloaded package directory `{0}`
-            in {0}.
             """.format(venvsourcedir))
 
     # run: python virtualenv.py --[no,system]-site-packages $DESTDIR


### PR DESCRIPTION
search for package expected binary  in downloaded packages - as oppose to make the assumption it is located in a specify location (e.g. <package>/<binary>.py )
this, for example, broke installer when dealing with new version of virtualenv 
should address  #650 

